### PR TITLE
UC1-S1 index action for users controller

### DIFF
--- a/iskolivery/app/controllers/users_controller.rb
+++ b/iskolivery/app/controllers/users_controller.rb
@@ -19,6 +19,16 @@
 # the UP Community
 class UsersController < ApplicationController
 
+	# only give @users if admin, otherwise give 403 Forbidden
+	def index
+
+		if !current_user.admin?
+			render status: :forbidden
+		end
+
+		@users = User.all
+	end
+
 	# render User homepage
 	def home
 		@user = current_user

--- a/iskolivery/config/routes.rb
+++ b/iskolivery/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   get 		'/home',		to:	'users#home' # user homepage
   get 		'/my_requests', to: 'users#my_requests' # user accepted requests
   post		'/accept',		to: 'users#accept_request' # accept a request
+  get		'/users',		to:	'users#index' # view all users as admin
 
   resources :requests
 

--- a/iskolivery/test/controllers/users_controller_test.rb
+++ b/iskolivery/test/controllers/users_controller_test.rb
@@ -1,9 +1,20 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
-  test "should get home" do
-    get users_home_url
-    assert_response :success
-  end
+	test "admin user view index" do
+		admin_user = users(:two)
+		post login_path, params: { session: { email: admin_user.email,
+											 password: 'password' } }
+		get '/users'
+		assert_response :success
+	end
+
+	test "regular user view index" do
+		regular_user = users(:one)
+		post login_path, params: { session: { email: regular_user.email,
+											 password: 'password' } }
+		get '/users'
+		assert_response 403
+	end
 
 end

--- a/iskolivery/test/fixtures/users.yml
+++ b/iskolivery/test/fixtures/users.yml
@@ -5,5 +5,6 @@ one:
   password_digest: <%= User.digest('password') %>
 
 two:
-  email: MyString
-  password_digest: MyString
+  email: two@test.com
+  admin: true
+  password_digest: <%= User.digest('password') %>


### PR DESCRIPTION
Passes collection of all `User` objects in database as `@users` to `view/users/index.html.erb`. Works only on admin accounts: error 403 forbidden is returned otherwise.