### PR TITLE
mark requests fulfilled and rate

### DIFF
--- a/iskolivery/app/controllers/requests_controller.rb
+++ b/iskolivery/app/controllers/requests_controller.rb
@@ -51,14 +51,10 @@ class RequestsController < ApplicationController
 		  assignment.request_status =
 			  RequestStatus.find_by(description: 'fulfilled')
 
-		  new_requester_rating = assignment.requester.rating
-							+ assignment.requester_rating
-							* Rails.configuration.new_rating_weight
+		  new_requester_rating = assignment.requester.rating + assignment.requester_rating * Rails.configuration.new_rating_weight
 		  assignment.requester.update(rating: new_requester_rating)
 
-		  new_fulfiller_rating = assignment.fulfiller.rating
-							+ assignment.fulfiller_rating
-							* Rails.configuration.new_rating_weight
+		  new_fulfiller_rating = assignment.fulfiller.rating + assignment.fulfiller_rating * Rails.configuration.new_rating_weight
 		  assignment.fulfiller.update(rating: new_fulfiller_rating)
 	  end
   end

--- a/iskolivery/app/controllers/requests_controller.rb
+++ b/iskolivery/app/controllers/requests_controller.rb
@@ -41,14 +41,25 @@ class RequestsController < ApplicationController
 	  assignment = Request.find(params[:id]).assignment
 
 	  if user == assignment.fulfiller
-		  assignment.requester_rating = params[:rating]
+		  assignment.update(requester_rating: params[:rating])
 	  else
-		  assignment.fulfiller_rating = params[:rating]
+		  assignment.update(fulfiller_rating: params[:rating])
 	  end
 
 	  # a rating of < 0 means the request hasn't been rated yet
 	  if assignment.requester_rating > 0 && assignment.fulfiller_rating > 0
-		  assignment.status = RequestStatus.find_by(description: 'fulfilled')
+		  assignment.request_status =
+			  RequestStatus.find_by(description: 'fulfilled')
+
+		  new_requester_rating = assignment.requester.rating
+							+ assignment.requester_rating
+							* Rails.configuration.new_rating_weight
+		  assignment.requester.update(rating: new_requester_rating)
+
+		  new_fulfiller_rating = assignment.fulfiller.rating
+							+ assignment.fulfiller_rating
+							* Rails.configuration.new_rating_weight
+		  assignment.fulfiller.update(rating: new_fulfiller_rating)
 	  end
   end
 

--- a/iskolivery/app/controllers/requests_controller.rb
+++ b/iskolivery/app/controllers/requests_controller.rb
@@ -47,7 +47,7 @@ class RequestsController < ApplicationController
 	  end
 
 	  # a rating of < 0 means the request hasn't been rated yet
-	  if assignment.requester_rating > 0 && assignment.fulfiller_rating > 0
+	  if assignment.requester_rating.to_f > 0 && assignment.fulfiller_rating.to_f > 0
 		  assignment.request_status = RequestStatus.find_by(description: 'fulfilled')
 
 		  new_requester_rating = assignment.requester.rating + assignment.requester_rating * Rails.configuration.new_rating_weight

--- a/iskolivery/app/controllers/requests_controller.rb
+++ b/iskolivery/app/controllers/requests_controller.rb
@@ -1,21 +1,21 @@
 # LICENSE
-# This is a course requirement for CS 192 Software Engineering II under the 
-# supervision of Asst. Prof. Ma. Rowena C. Solamo of the Department of Computer 
-# Science, College of Engineering, University of the Philippines, Diliman for 
+# This is a course requirement for CS 192 Software Engineering II under the
+# supervision of Asst. Prof. Ma. Rowena C. Solamo of the Department of Computer
+# Science, College of Engineering, University of the Philippines, Diliman for
 # the AY 2018-2019
-# 
-# This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 
+#
+# This work is licensed under a Creative Commons Attribution-ShareAlike 4.0
 # International License.
-# 
+#
 # Author: Marc Teves
-# 
+#
 # CODE HISTORY
-# 
+#
 # INFORMATION
 # File creation: February 5, 2019
 # Development group: Group 1 - Iskolivery
 # Client group: None
-# Purpose of the software: To create a crowdsourced courier service for 
+# Purpose of the software: To create a crowdsourced courier service for
 # the UP Community
 class RequestsController < ApplicationController
   def view
@@ -34,6 +34,22 @@ class RequestsController < ApplicationController
 
 	  user.postings.create!(request_id: request.id)
 	  redirect_back fallback_location: '/home'
+  end
+
+  def fulfill
+	  user = current_user
+	  assignment = Request.find(params[:id]).assignment
+
+	  if user == assignment.fulfiller
+		  assignment.requester_rating = params[:rating]
+	  else
+		  assignment.fulfiller_rating = params[:rating]
+	  end
+
+	  # a rating of < 0 means the request hasn't been rated yet
+	  if assignment.requester_rating > 0 && assignment.fulfiller_rating > 0
+		  assignment.status = RequestStatus.find_by(description: 'fulfilled')
+	  end
   end
 
   private

--- a/iskolivery/app/controllers/requests_controller.rb
+++ b/iskolivery/app/controllers/requests_controller.rb
@@ -48,12 +48,14 @@ class RequestsController < ApplicationController
 
 	  # a rating of < 0 means the request hasn't been rated yet
 	  if assignment.requester_rating.to_f > 0 && assignment.fulfiller_rating.to_f > 0
-		  assignment.request_status = RequestStatus.find_by(description: 'fulfilled')
+		  assignment.request_status=(RequestStatus.find_by(description: 'fulfilled'))
 
-		  new_requester_rating = assignment.requester.rating + assignment.requester_rating * Rails.configuration.new_rating_weight
+		  # new_requester_rating = assignment.requester.rating + assignment.requester_rating * Rails.configuration.new_rating_weight
+		  new_requester_rating = assignment.requester.rating.to_f + assignment.requester_rating.to_f * 0.05
 		  assignment.requester.update(rating: new_requester_rating)
 
-		  new_fulfiller_rating = assignment.fulfiller.rating + assignment.fulfiller_rating * Rails.configuration.new_rating_weight
+		  # new_fulfiller_rating = assignment.fulfiller.rating + assignment.fulfiller_rating * Rails.configuration.new_rating_weight
+		  new_fulfiller_rating = assignment.fulfiller.rating.to_f + assignment.fulfiller_rating.to_f * 0.05	  
 		  assignment.fulfiller.update(rating: new_fulfiller_rating)
 	  end
   end

--- a/iskolivery/app/controllers/requests_controller.rb
+++ b/iskolivery/app/controllers/requests_controller.rb
@@ -48,8 +48,7 @@ class RequestsController < ApplicationController
 
 	  # a rating of < 0 means the request hasn't been rated yet
 	  if assignment.requester_rating > 0 && assignment.fulfiller_rating > 0
-		  assignment.request_status =
-			  RequestStatus.find_by(description: 'fulfilled')
+		  assignment.request_status = RequestStatus.find_by(description: 'fulfilled')
 
 		  new_requester_rating = assignment.requester.rating + assignment.requester_rating * Rails.configuration.new_rating_weight
 		  assignment.requester.update(rating: new_requester_rating)

--- a/iskolivery/app/controllers/users_controller.rb
+++ b/iskolivery/app/controllers/users_controller.rb
@@ -44,13 +44,16 @@ class UsersController < ApplicationController
 
 		# active requests are the requests posted by user
 		# which have status accepted (1)
+		#
+		active_status = RequestStatus.find_by(description: "accepted").id
 		@active_requests = Assignment.where(requester_id: @user.id)
-			.where('request_status_id = 1')
+			.where(request_status_id: active_status)
 
 		# pending requests are requests posted by user
 		# which have status pending (0)
+		pending_status = RequestStatus.find_by(description: "pending accept").id
 		@pending_requests = Assignment.where(requester_id: @user.id)
-			.where('request_status_id = 0')
+			.where(request_status_id: pending_status)
 	end
 
 	# render accepted requests page
@@ -69,7 +72,8 @@ class UsersController < ApplicationController
 
 		assignment = Assignment.find_by(request_id: params[:request_id])
 		user.accepteds << assignment
-		assignment.update(request_status_id: 1) # status: accepted
+		accepted_status = RequestStatus.find_by(description: "accepted").id
+		assignment.update(request_status_id: accepted_status) # status: accepted
 
 		redirect_back fallback_location: '/home'
 	end
@@ -80,7 +84,8 @@ class UsersController < ApplicationController
 
 		assignment = Assignment.find_by(request_id: params[:request_id])
 		user.accepteds.delete(assignment)
-		assignment.update(request_status_id: 3) # status: cancelled
+		cancelled_status = RequestStatus.find_by(description: "cancelled").id
+		assignment.update(request_status_id: cancelled_status) # status: cancelled
 
 		redirect_back fallback_location: '/home'
 	end

--- a/iskolivery/app/models/assignment.rb
+++ b/iskolivery/app/models/assignment.rb
@@ -28,4 +28,8 @@ class Assignment < ApplicationRecord
 	belongs_to :request_status,
 		default: -> { RequestStatus.find_by(description: 'pending accept') }
 
+	# use these default values to track if one party hasn't rated yet
+	attribute :fulfiller_rating, default: -1
+	attribute :requester_rating, default: -1
+
 end

--- a/iskolivery/app/models/user.rb
+++ b/iskolivery/app/models/user.rb
@@ -1,21 +1,21 @@
 # LICENSE
-# This is a course requirement for CS 192 Software Engineering II under the 
-# supervision of Asst. Prof. Ma. Rowena C. Solamo of the Department of Computer 
-# Science, College of Engineering, University of the Philippines, Diliman for 
+# This is a course requirement for CS 192 Software Engineering II under the
+# supervision of Asst. Prof. Ma. Rowena C. Solamo of the Department of Computer
+# Science, College of Engineering, University of the Philippines, Diliman for
 # the AY 2018-2019
-# 
-# This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 
+#
+# This work is licensed under a Creative Commons Attribution-ShareAlike 4.0
 # International License.
-# 
+#
 # Author: Marc Teves
-# 
+#
 # CODE HISTORY
-# 
+#
 # INFORMATION
 # File creation: February 5, 2019
 # Development group: Group 1 - Iskolivery
 # Client group: None
-# Purpose of the software: To create a crowdsourced courier service for 
+# Purpose of the software: To create a crowdsourced courier service for
 # the UP Community
 class User < ApplicationRecord
 
@@ -26,7 +26,7 @@ class User < ApplicationRecord
 	has_many :accepteds, 	class_name: "Assignment",
 							foreign_key: "fulfiller_id"
 
-	# these associations allow a User to access posted and accepted 
+	# these associations allow a User to access posted and accepted
 	# requests directly using User.<association>
 	has_many :posted_requests,		through: :postings, source: :request
 	has_many :accepted_requests,	through: :accepteds, source: :request
@@ -38,6 +38,8 @@ class User < ApplicationRecord
 		# uniqueness: { case_sensitive: false }
 	validates :password, presence: true, length: { minimum: 8 }, on: :create
 	validates :name, presence: true
+
+	attribute :rating, default: 4.50
 
 	has_secure_password
 

--- a/iskolivery/app/views/layouts/_footer.html.erb
+++ b/iskolivery/app/views/layouts/_footer.html.erb
@@ -1,0 +1,20 @@
+<!-- <div class="ui vertical footer segment" id="footer"> -->
+<div class = "ui inverted footer segment" style = "background:#921517">
+<div class="ui container">
+  <div class="ui stackable inverted divided equal height stackable grid">
+    <div class="two wide column">
+      <h4 class="ui inverted header">About</h4>
+      <div class="ui inverted link list">
+        <a href="http://www.pokemon.com/us/pokedex/" class="item">Iskolivery</a>
+        <a href="#" class="item">Contact Us</a>
+        <a href="http://www.facebook.com/bridgetnoelleee" class="item">CS 192 Students</a>
+      </div>
+    </div>
+
+    <div class="thirteen wide column">
+      <h4 class="ui inverted header">Iskolivery: A Crowdsourced Courier Service</h4>
+      <p>The Pokédex section has a wealth of information on all the Pokémon creatures from the entire game series. On the main list pages you can see the various stats of each Pokémon.</p>
+    </div>
+  </div>
+</div>
+</div>

--- a/iskolivery/app/views/users/_accepted_request.html.erb
+++ b/iskolivery/app/views/users/_accepted_request.html.erb
@@ -51,9 +51,16 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 		<div class = "ui star rating" id = "userratereq" data-max-rating="5"></div>
 	</div>
 	<div class="actions">
-		<button class="ui green approve button" id = "submitrate">
+
+		<%= form_tag request_fulfill_path(request.request_id), method: :patch do -%>
+            	<%= hidden_field_tag :rating, 1 %>
+
+		<button class="ui green approve button" id = "submitratereq">
 			Submit
 		</button>
+
+		<% end -%>
+
 	</div>
 </div>
 
@@ -62,6 +69,11 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 		$('#markdonereq').click(function(){
 	    	$('#donemodalreq').modal('show');    
 		});
+
+		$('#submitratereq').click(function(){
+			var rating = $('#userrating').rating('get rating');
+			$('#rating').value = rating;
+		});		
 	});
 </script>
 

--- a/iskolivery/app/views/users/_accepted_request.html.erb
+++ b/iskolivery/app/views/users/_accepted_request.html.erb
@@ -29,23 +29,25 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 			<p><strong>Location: </strong><%= request.request.location.name %></p>
 			<p style:"margin-bottom:-10px"><strong>Description: </strong><%= request.request.item_name %></p>
 		</div>
+		<br>
 <!-- 		<button class="ui right floated mini inverted red button">
  -->			<%= form_tag cancel_path do -%>
 			<%= hidden_field_tag :request_id, request.request_id %>
 			<%#= submit_tag 'Cancel' %>
 			<button class="ui mini right floated negative button" type="submit">Cancel</button>
-			<% end -%>	
-			<button class="ui mini right floated positive button" id="markdonereq">Mark as done</button>
+			<% end -%>
+			<button class="ui mini right floated positive button" id="markdonereq">Done</button>
 		<!-- </button> -->
 	</div>
 </div>
 
-<div class = "ui modal" id="donemodalreq">
+<div class = "ui tiny modal" id="donemodalreq">
 	<i class="close icon"></i>
 	<div class="header" style = "background-color:#921517">
-		<h2>Rate Requester</h2>
+		<h2 style = "color:#FFFFFF">Rate Requester</h2>
 	</div>
 	<div class="content">
+		<strong><%= request.requester.name %>: </strong>		
 		<div class = "ui star rating" id = "userratereq" data-max-rating="5"></div>
 	</div>
 	<div class="actions">

--- a/iskolivery/app/views/users/_accepted_request.html.erb
+++ b/iskolivery/app/views/users/_accepted_request.html.erb
@@ -35,9 +35,33 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 			<%#= submit_tag 'Cancel' %>
 			<button class="ui mini right floated negative button" type="submit">Cancel</button>
 			<% end -%>	
+			<button class="ui mini right floated positive button" id="markdonereq">Mark as done</button>
 		<!-- </button> -->
 	</div>
 </div>
+
+<div class = "ui modal" id="donemodalreq">
+	<i class="close icon"></i>
+	<div class="header" style = "background-color:#921517">
+		<h2>Rate Requester</h2>
+	</div>
+	<div class="content">
+		<div class = "ui star rating" id = "userratereq" data-max-rating="5"></div>
+	</div>
+	<div class="actions">
+		<button class="ui green approve button" id = "submitrate">
+			Submit
+		</button>
+	</div>
+</div>
+
+<script>
+	$(document).ready(function(){
+		$('#markdonereq').click(function(){
+	    	$('#donemodalreq').modal('show');    
+		});
+	});
+</script>
 
 <!--
 <tr>

--- a/iskolivery/app/views/users/_active_accepted_request.html.erb
+++ b/iskolivery/app/views/users/_active_accepted_request.html.erb
@@ -26,14 +26,14 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 			<%= hidden_field_tag :request_id, request.request_id %>
 			<button class="ui mini right floated negative button" type="submit">Cancel</button>
 			<% end -%>	
-			<button class="ui mini right floated negative green button" id="markdone">Mark as done</button>
+			<button class="ui mini right floated positive button" id="markdonefullfiller">Mark as done</button>
 	</div>
 </div>
 
 <div class = "ui modal" id="donemodal">
 	<i class="close icon"></i>
 	<div class="header" style = "background-color:#921517">
-		<h2>Rate User</h2>
+		<h2>Rate Fulfiller</h2>
 	</div>
 	<div class="content">
 		<div class = "ui star rating" id = "userratereq" data-max-rating="5"></div>
@@ -47,7 +47,7 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 
 <script>
 	$(document).ready(function(){
-		$('#markdone').click(function(){
+		$('#markdonefullfiller').click(function(){
 	    	$('#donemodal').modal('show');    
 		});
 	});

--- a/iskolivery/app/views/users/_active_accepted_request.html.erb
+++ b/iskolivery/app/views/users/_active_accepted_request.html.erb
@@ -27,8 +27,7 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 			<%= hidden_field_tag :request_id, request.request_id %>
 			<button class="ui mini right floated negative button" type="submit">Cancel</button>
 			<% end -%>	
-
-				<button class="ui mini right floated positive button" id="markdonefullfiller">Confirm</button>
+			<button class="ui mini right floated positive button" id="markdonefullfiller">Confirm</button>
 
 	</div>
 </div>
@@ -67,6 +66,4 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 		});
 
 	});
-
-
 </script>

--- a/iskolivery/app/views/users/_active_accepted_request.html.erb
+++ b/iskolivery/app/views/users/_active_accepted_request.html.erb
@@ -26,5 +26,9 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 			<%= hidden_field_tag :request_id, request.request_id %>
 			<button class="ui mini right floated negative button" type="submit">Cancel</button>
 			<% end -%>	
+			<%= form_tag cancel_path do -%>
+			<%= hidden_field_tag :request_id, request.request_id %>
+			<button class="ui mini right floated negative green button" type="submit">Mark as done</button>
+			<% end -%>	
 	</div>
 </div>

--- a/iskolivery/app/views/users/_active_accepted_request.html.erb
+++ b/iskolivery/app/views/users/_active_accepted_request.html.erb
@@ -26,9 +26,29 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 			<%= hidden_field_tag :request_id, request.request_id %>
 			<button class="ui mini right floated negative button" type="submit">Cancel</button>
 			<% end -%>	
-			<%= form_tag cancel_path do -%>
-			<%= hidden_field_tag :request_id, request.request_id %>
-			<button class="ui mini right floated negative green button" type="submit">Mark as done</button>
-			<% end -%>	
+			<button class="ui mini right floated negative green button" id="markdone">Mark as done</button>
 	</div>
 </div>
+
+<div class = "ui modal" id="donemodal">
+	<i class="close icon"></i>
+	<div class="header" style = "background-color:#921517">
+		<h2>Rate User</h2>
+	</div>
+	<div class="content">
+		<div class = "ui star rating" id = "userratereq" data-max-rating="5"></div>
+	</div>
+	<div class="actions">
+		<button class="ui green approve button" id = "submitrate">
+			Submit
+		</button>
+	</div>
+</div>
+
+<script>
+	$(document).ready(function(){
+		$('#markdone').click(function(){
+	    	$('#donemodal').modal('show');    
+		});
+	});
+</script>

--- a/iskolivery/app/views/users/_active_accepted_request.html.erb
+++ b/iskolivery/app/views/users/_active_accepted_request.html.erb
@@ -21,27 +21,37 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 			</div>
 			<p><strong>Location: </strong><%= request.request.location.name %></p>
 			<p style:"margin-bottom:-10px"><strong>Description: </strong><%= request.request.item_name %></p>
+			<br>
 		</div>
 			<%= form_tag cancel_path do -%>
 			<%= hidden_field_tag :request_id, request.request_id %>
 			<button class="ui mini right floated negative button" type="submit">Cancel</button>
 			<% end -%>	
-			<button class="ui mini right floated positive button" id="markdonefullfiller">Mark as done</button>
+
+				<button class="ui mini right floated positive button" id="markdonefullfiller">Confirm</button>
+
 	</div>
 </div>
 
-<div class = "ui modal" id="donemodal">
+<div class = "ui tiny modal" id="donemodal">
 	<i class="close icon"></i>
 	<div class="header" style = "background-color:#921517">
-		<h2>Rate Fulfiller</h2>
+		<h2 style = "color:#FFFFFF">Rate Fulfiller</h2>
 	</div>
 	<div class="content">
-		<div class = "ui star rating" id = "userratereq" data-max-rating="5"></div>
+		<strong><%= request.fulfiller.name %>: </strong>
+		<div class = "ui star rating" id = "userrating" data-max-rating="5"></div>
 	</div>
 	<div class="actions">
+
+		<%= form_tag request_fulfill_path(request.request_id), method: :patch do -%>
+            	<%= hidden_field_tag :rating, 1 %>
+
 		<button class="ui green approve button" id = "submitrate">
 			Submit
 		</button>
+
+		<% end -%>
 	</div>
 </div>
 
@@ -50,5 +60,13 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 		$('#markdonefullfiller').click(function(){
 	    	$('#donemodal').modal('show');    
 		});
+
+		$('#submitrate').click(function(){
+			var rating = $('#userrating').rating('get rating');
+			$('#rating').value = rating;
+		});
+
 	});
+
+
 </script>

--- a/iskolivery/app/views/users/_request.html.erb
+++ b/iskolivery/app/views/users/_request.html.erb
@@ -15,9 +15,12 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 <div class="ui card fluid">
 	<div class="content">
 		<div class="header">
-			<a href="#"><%= request.requester.email %></a>
 			<div class = "right floated meta" style="color:#009900">
 				P<%= request.request.bounty %>
+			</div>
+			<a href="#"><%= request.requester.email %></a>
+			<div class = "meta" style="color:#F9DC5C">
+				P<%= request.requester.rating %>/5.0
 			</div>
 		</div>
 		<div class="description">

--- a/iskolivery/app/views/users/_request.html.erb
+++ b/iskolivery/app/views/users/_request.html.erb
@@ -19,9 +19,7 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 				P<%= request.request.bounty %>
 			</div>
 			<a href="#"><%= request.requester.email %></a>
-			<div class = "meta" style="color:#F9DC5C">
-				P<%= request.requester.rating %>/5.0
-			</div>
+			<div class = "ui star rating" id = "userratereq" data-max-rating="5"></div>
 		</div>
 		<div class="description">
 			<p><strong>Location: </strong><%= request.request.location.name %></p>
@@ -38,6 +36,18 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 		<!-- </div> -->
 	<!-- </div> -->
 </div>
+
+<script>
+	$(document).ready(function(){
+	    // All your normal JS code goes in here
+	    $(".rating").rating();
+	});
+	$(document).ready(function(){
+		var rate = <%= @user.rating %>;
+    	$('#userratereq').rating('set rating', rate);
+    	$('#userratereq').rating('disable');
+    });
+</script>
 
 <!--fluid ui mini primary button
 <tr>

--- a/iskolivery/app/views/users/home.html.erb
+++ b/iskolivery/app/views/users/home.html.erb
@@ -61,8 +61,7 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 								<i class="floated edit link icon"><%= link_to 'Edit', user_view_edit_path(@user)%></i>
 								<span>
 									<h2 style="margin-bottom:0px"><%= @user.name %></h2>
-									<div class = "ui star rating" id = "userrating" data-max-rating="5">
-									</div>
+									<div class = "ui star rating" id = "userratereq" data-max-rating="5"></div>
 									<div class="meta">
 										College of Engineering
 								    </div>
@@ -195,8 +194,12 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 				$(document).ready(function(){
 				    // All your normal JS code goes in here
 				    $(".rating").rating();
+				    var rate = <%= @user.rating %>;
+				    $('#userratereq').rating('set rating', Math.floor(rate));
+				    $('#userratereq').rating('disable');
 				});
 			</script>
-		</div>
+		</div> 
+		<%#= render 'layouts/footer' %>		
 	</body>
 </html>

--- a/iskolivery/app/views/users/home.html.erb
+++ b/iskolivery/app/views/users/home.html.erb
@@ -57,9 +57,11 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 								<i class="floated edit link icon"><%= link_to 'Edit', user_view_edit_path(@user)%></i>
 								<span>
 									<h2 style="margin-bottom:0px"><%= @user.name %></h2>
-									
+									<div class = "right floated meta" style="color:#921517">
+										<%= @user.rating %>/5.0
+									</div>
 									<div class="meta">
-									College of Engineering
+										College of Engineering
 								    </div>
 								</span>        
 								<hr>                

--- a/iskolivery/app/views/users/home.html.erb
+++ b/iskolivery/app/views/users/home.html.erb
@@ -192,12 +192,7 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 				    // All your normal JS code goes in here
 				    $(".rating").rating();
 				});
-				$(document).ready(function(){
-					var rate = <%= @user.rating %>;
-			    	$('#userrating').rating('set rating', rate);
-			    	$('#userrating').rating('disable');
-			    });
-		    </script>
-		</div> 
+			</script>
+		</div>
 	</body>
 </html>

--- a/iskolivery/app/views/users/home.html.erb
+++ b/iskolivery/app/views/users/home.html.erb
@@ -57,8 +57,7 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 								<i class="floated edit link icon"><%= link_to 'Edit', user_view_edit_path(@user)%></i>
 								<span>
 									<h2 style="margin-bottom:0px"><%= @user.name %></h2>
-									<div class = "right floated meta" style="color:#921517">
-										<%= @user.rating %>/5.0
+									<div class = "ui star rating" id = "userrating" data-max-rating="5">
 									</div>
 									<div class="meta">
 										College of Engineering
@@ -188,6 +187,16 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 				</div>
 			</div>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.js"></script>
+			<script>
+				$(document).ready(function(){
+				    // All your normal JS code goes in here
+				    $(".rating").rating();
+				});
+				$(document).ready(function(){
+					var rate = <%= @user.rating %>;
+			    	$('#userrating').rating('set rating', rate);
+			    });
+		    </script>
 		</div> 
 	</body>
 </html>

--- a/iskolivery/app/views/users/home.html.erb
+++ b/iskolivery/app/views/users/home.html.erb
@@ -195,6 +195,7 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 				$(document).ready(function(){
 					var rate = <%= @user.rating %>;
 			    	$('#userrating').rating('set rating', rate);
+			    	$('#userrating').rating('disable');
 			    });
 		    </script>
 		</div> 

--- a/iskolivery/app/views/users/home.html.erb
+++ b/iskolivery/app/views/users/home.html.erb
@@ -17,7 +17,11 @@ This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 Intern
 	<head>
 		<meta charset= "utf-8">
 		<title>Accepted Requests</title>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
+          <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
+          <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/components/modal.min.css">
+          <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+          <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.js"></script>
+          <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/components/modal.min.js"></script>
 	
 		<style type="text/css">
 			body {

--- a/iskolivery/app/views/users/index.html.erb
+++ b/iskolivery/app/views/users/index.html.erb
@@ -19,7 +19,6 @@
           <title>Accepted Requests</title>
           <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
           <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/components/modal.min.css">
-
           <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
           <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.js"></script>
           <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/components/modal.min.js"></script>

--- a/iskolivery/config/application.rb
+++ b/iskolivery/config/application.rb
@@ -10,6 +10,7 @@ module Iskolivery
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+	config.new_rating_weight = 0.05
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/iskolivery/config/routes.rb
+++ b/iskolivery/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   get		  '/user/:id/edit',	to:	'users#view_edit', as: 'user_view_edit' # view form for editing
   patch		'/user/:id',	    to: 'users#edit', as: 'user_edit' # edit user with params
   patch		'/user/:id/disable',	    to: 'users#disable', as: 'user_disable' # disable a user
-  patch		'request/:id/fulfill',	to: 'request#fulfill', as: 'request_fulfill'
+  patch		'request/:id/fulfill',	to: 'requests#fulfill', as: 'request_fulfill'
 
 
   resources :requests

--- a/iskolivery/config/routes.rb
+++ b/iskolivery/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   get		  '/user/:id/edit',	to:	'users#view_edit', as: 'user_view_edit' # view form for editing
   patch		'/user/:id',	    to: 'users#edit', as: 'user_edit' # edit user with params
   patch		'/user/:id/disable',	    to: 'users#disable', as: 'user_disable' # disable a user
+  patch		'request/:id/fulfill',	to: 'request#fulfill', as: 'request_fulfill'
 
 
   resources :requests

--- a/iskolivery/db/migrate/20190403055058_add_rating_to_users.rb
+++ b/iskolivery/db/migrate/20190403055058_add_rating_to_users.rb
@@ -1,0 +1,5 @@
+class AddRatingToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :rating, :float
+  end
+end

--- a/iskolivery/db/migrate/20190404123454_add_requester_rating_to_assignments.rb
+++ b/iskolivery/db/migrate/20190404123454_add_requester_rating_to_assignments.rb
@@ -1,0 +1,5 @@
+class AddRequesterRatingToAssignments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :assignments, :requester_rating, :float
+  end
+end

--- a/iskolivery/db/migrate/20190404123515_add_fulfiller_rating_to_assignments.rb
+++ b/iskolivery/db/migrate/20190404123515_add_fulfiller_rating_to_assignments.rb
@@ -1,0 +1,5 @@
+class AddFulfillerRatingToAssignments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :assignments, :fulfiller_rating, :float
+  end
+end

--- a/iskolivery/db/schema.rb
+++ b/iskolivery/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190403055058) do
+ActiveRecord::Schema.define(version: 20190404123515) do
 
   create_table "assignments", force: :cascade do |t|
     t.integer "requester_id"
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(version: 20190403055058) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "request_status_id"
+    t.float "requester_rating"
+    t.float "fulfiller_rating"
     t.index ["request_id"], name: "index_assignments_on_request_id"
     t.index ["request_status_id"], name: "index_assignments_on_request_status_id"
   end

--- a/iskolivery/db/schema.rb
+++ b/iskolivery/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190328120830) do
+ActiveRecord::Schema.define(version: 20190403055058) do
 
   create_table "assignments", force: :cascade do |t|
     t.integer "requester_id"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20190328120830) do
     t.boolean "verified", default: false, null: false
     t.string "name"
     t.boolean "enabled", default: true, null: false
+    t.float "rating"
   end
 
 end

--- a/requestform.html
+++ b/requestform.html
@@ -67,9 +67,13 @@
 								<img class="ui avatar bordered circular image" src="yukataw.png" style="width:50px;height:50px;">
 								<span>
 									<h2 style="margin-bottom:0px">Username</h2>
+									<div class = "right floated meta" style="color:#921517">
+										4.5/5.0
+									</div>
 									<div class="meta">
 								    	College of Engineering
 								    </div>
+
 								</span>		
 								<hr>				
 								<div class="segment">
@@ -84,22 +88,25 @@
 												<p>10 am at CS Library</p>
 
 											</div>
-											
 											<button class="ui mini inverted right floated red button">
 												Cancel
 											</button>
+											<button class="ui mini inverted right floated green button">
+												Mark as done
+											</button>				
 										</div>
 									</div>
 									<div class="ui card">
 										<div class="content">
 											<div class="description">
+												<div class = "right floated meta" style="color:#FFAA25">
+													Pending
+												</div>
 												<p style:"margin-bottom:-10px">Do this for me</p>
 												<p>10 am at CS Library</p>
 											</div>
-											<div class = "right floated meta" style="color:#FFAA25">
-												Pending
-											</div>
-											<button class="ui mini inverted red button">
+											
+											<button class="ui mini right floated inverted red button">
 												Cancel
 											</button>
 										</div>
@@ -170,10 +177,14 @@
 						<div class="ui card fluid">
 							<div class="content">
 								<div class="header">
-									<a href="/lol" style="color:#000000">Username</a>
 									<div class = "right floated meta" style="color:#44CC44">
 										80 PHP
 									</div>
+									<a href="/lol" style="color:#000000">Username</a>
+									<div class = "meta" style="color:#F9DC5C">
+										4.5/5.0
+									</div>
+									
 								</div>
 								<div class="description">
 										<p>Do this for me</p>


### PR DESCRIPTION
Added functionality for marking requests as fulfilled. Updating a user's "rating" is still not done, however requests can be rated already. It just won't update the user's rating.

named path to action: `request_fulfill(:id)`
HTTP method: `PATCH`
additional parameters to pass: `:rating`

Tests haven't been written yet, but pushing this early so you guys can see.